### PR TITLE
Add comprehensive .gitignore for Vite + React + TypeScript PWA project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,97 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Production build
+dist/
+dist-ssr/
+build/
+*.local
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Vite
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+
+# PWA
+dev-dist/
+workbox-*.js
+sw.js
+
+# TypeScript
+*.tsbuildinfo
+
+# Testing
+coverage/
+.nyc_output/
+
+# OS files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+desktop.ini
+
+# Linux
+.directory
+.Trash-*
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional stylelint cache
+.stylelintcache
+
+# Stores
+*.log
+.cache/
+.parcel-cache/
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.temp
+
+# Monaco Editor
+.monaco/
+
+# ML Model files (future)
+*.onnx
+*.bin
+*.safetensors
+models/
+!models/.gitkeep


### PR DESCRIPTION
## Add comprehensive .gitignore for Vite + React + TypeScript PWA project

This PR adds a complete `.gitignore` file tailored for your prompt editing PWA project.

### What's included:
- **Node/npm artifacts**: `node_modules/`, npm logs, cache directories
- **Build outputs**: `dist/`, `build/`, Vite-specific builds
- **IDE files**: VS Code, IntelliJ IDEA, vim swap files
- **Environment files**: All `.env` variants for secure config
- **OS files**: macOS `.DS_Store`, Linux `.directory`, Windows `Thumbs.db`
- **Vite-specific**: Timestamp files, dev-dist for PWA
- **PWA files**: Service worker builds, workbox files
- **TypeScript**: Build info files
- **Future ML models**: Pre-configured to ignore `.onnx`, `.bin`, `.safetensors` files while allowing a `.gitkeep` in the models directory

### Special considerations:
- Keeps select VS Code config files that are useful to share (extensions, settings)
- Ignores Monaco editor cache if it generates any
- Ready for when you add ML model files (won't accidentally commit large binaries)

This should cover all the common files you don't want in version control for this stack.